### PR TITLE
manage GIL acquisition when doing things inside of pdal::plang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,6 @@ jobs:
         use-mamba: true
         auto-update-conda: true
         environment-file: .github/environment.yml
-        extra-specs: |
-          python=${{ matrix.python-version }}
 
 
     - name: Install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         python setup.py sdist
         ls dist
 
-    - uses: pypa/gh-action-pypi-publish@master
+    - uses: pypa/gh-action-pypi-publish@release/v1
       name: Publish package
       if: github.event_name == 'release' && github.event.action == 'published'
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,19 +24,23 @@ jobs:
       fail-fast: true
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
 
     steps:
     - name: Check out
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: conda-incubator/setup-miniconda@v3
       with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
+        auto-update-conda: true
         environment-file: .github/environment.yml
         extra-specs: |
           python=${{ matrix.python-version }}
-          sel(linux): compilers
+
 
     - name: Install
       shell: bash -l {0}
@@ -67,11 +71,14 @@ jobs:
         python-version: ['3.9']
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - name: Setup micromamba
+      uses: conda-incubator/setup-miniconda@v3
       with:
-        channels: conda-forge
-        python-version: ${{ matrix.python-version }}
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        use-mamba: true
+        auto-update-conda: true
         mamba-version: "*"
 
     - name: Dependencies

--- a/pdal/filters/PythonFilter.cpp
+++ b/pdal/filters/PythonFilter.cpp
@@ -148,6 +148,7 @@ PointViewSet PythonFilter::run(PointViewPtr view)
     log()->get(LogLevel::Debug5) << "filters.python " << *m_script <<
         " processing " << (int)view->size() << " points." << std::endl;
 
+    plang::gil_scoped_acquire acquire;
     m_pythonMethod->execute(view, getMetadata());
 
     PointViewSet viewSet;

--- a/pdal/plang/Environment.cpp
+++ b/pdal/plang/Environment.cpp
@@ -116,6 +116,7 @@ EnvironmentPtr Environment::get()
     {
         g_environment = new Environment();
     };
+    gil_scoped_acquire acquire;
     std::call_once(flag, init);
     return g_environment;
 }
@@ -150,8 +151,10 @@ Environment::Environment()
             throw pdal_error("unable to add redirector module!");
     }
 
+
     initNumpy();
     PyImport_ImportModule("redirector");
+
 }
 
 Environment::~Environment()

--- a/pdal/plang/Environment.hpp
+++ b/pdal/plang/Environment.hpp
@@ -47,6 +47,7 @@
 
 #include "Redirector.hpp"
 #include "Script.hpp"
+#include "gil.hpp"
 
 namespace pdal
 {

--- a/pdal/plang/Invocation.cpp
+++ b/pdal/plang/Invocation.cpp
@@ -122,6 +122,7 @@ Invocation::Invocation(const Script& script, MetadataNode m,
     m_script(script), m_inputMetadata(m), m_pdalargs(pdalArgs)
 {
     Environment::get();
+    gil_scoped_acquire acquire;
     compile();
 }
 
@@ -357,6 +358,7 @@ PyObject* getPyJSON(std::string const& s)
 // Returns a new reference to a dictionary of numpy arrays/names.
 PyObject *Invocation::prepareData(PointViewPtr& view)
 {
+    gil_scoped_acquire acquire;
     PointLayoutPtr layout(view->m_pointTable.layout());
     Dimension::IdList const& dims = layout->dims();
 

--- a/pdal/plang/gil.hpp
+++ b/pdal/plang/gil.hpp
@@ -45,6 +45,8 @@ public:
 };
 
 
+
+
 } // plang
 
 }  // pdal

--- a/pdal/plang/gil.hpp
+++ b/pdal/plang/gil.hpp
@@ -1,0 +1,50 @@
+/*
+    pybind11/gil.h: RAII helpers for managing the GIL
+
+    Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file.
+*/
+
+#pragma once
+
+#include <Python.h>
+
+
+namespace pdal
+{
+namespace plang
+{
+
+
+class gil_scoped_acquire {
+    PyGILState_STATE state;
+
+public:
+    gil_scoped_acquire() : state{PyGILState_Ensure()} {}
+    gil_scoped_acquire(const gil_scoped_acquire &) = delete;
+    gil_scoped_acquire &operator=(const gil_scoped_acquire &) = delete;
+    ~gil_scoped_acquire() { PyGILState_Release(state); }
+    void disarm() {}
+};
+
+class gil_scoped_release {
+    PyThreadState *state;
+
+public:
+    // PRECONDITION: The GIL must be held when this constructor is called.
+    gil_scoped_release() {
+        assert(PyGILState_Check());
+        state = PyEval_SaveThread();
+    }
+    gil_scoped_release(const gil_scoped_release &) = delete;
+    gil_scoped_release &operator=(const gil_scoped_release &) = delete;
+    ~gil_scoped_release() { PyEval_RestoreThread(state); }
+    void disarm() {}
+};
+
+
+} // plang
+
+}  // pdal

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r", encoding="utf-8") as fp:
 
 setup(
     name="pdal-plugins",
-    version="1.2.1",
+    version="1.3.0",
     description="Point cloud data processing Python plugins",
     license="BSD",
     keywords="point cloud spatial",


### PR DESCRIPTION
We want to be sanitary with the GIL so that we can release it in the PDAL Python extension. One area where that's really important is the log/redirect stuff this package provides. This PR implements pybind11's simplified `gil_scoped_acquire` and `gil_scoped_release` classes that handle management of the state, and then uses these to protect various calls where we need it.